### PR TITLE
add support for rails 7

### DIFF
--- a/lib/scim_rails/version.rb
+++ b/lib/scim_rails/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ScimRails
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/scim_rails.gemspec
+++ b/scim_rails.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.required_ruby_version = ">= 2.4"
-  s.add_dependency "rails", ">= 5.0", "< 6.2"
+  s.required_ruby_version = "~> 3.1"
+  s.add_dependency "rails", ">= 6.0", "<= 7.1"
   s.add_runtime_dependency "jwt", ">= 1.5"
   s.test_files = Dir["spec/**/*"]
 


### PR DESCRIPTION
## Why?

This PR removes the bounds for rails 7 in order to let host projects upgrade to rails 7
